### PR TITLE
Fix Uncaught SecurityError when loading img from external URL.

### DIFF
--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -164,6 +164,7 @@ crop.factory('cropHost', ['$document', 'cropAreaCircle', 'cropAreaSquare', funct
       events.trigger('image-updated');
       if(!!imageSource) {
         var newImage = new Image();
+        newImage.crossOrigin = 'anonymous';
         newImage.onload = function(){
           events.trigger('load-done');
           image=newImage;


### PR DESCRIPTION
Added crossOrigin attribute to loading of images to fix #12.

[Documentation for CORS images](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image) by MDN.
