### PR TITLE
Add ngAnnotation for unminified script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,7 @@ gulp.task('scripts', function(){
       Config.paths.source.js + '/classes/*.js',
       Config.paths.source.js + '/ng-img-crop.js'
     ])
+    .pipe(ngAnnotate())
     .pipe(concat(pkg.name+'.js', {
       separator: '\n\n',
       process: function(src) {


### PR DESCRIPTION
Unminified script in bower package should include annotation to be ready to go with custom minification. I will allow to use full version of libraries locally (for debug purpose) and minify them with production build.

Im sorry if i took it wrong. I cant say what is your delivery pipeline just by quick look at gulpfile. Its just an idea.
