### PR TITLE
Aspect ratio, crop data, original image data, and fix for hidden canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ The following code enables to select an image using a file input and crop it. Th
    [result-image-size="{number}"]
    [result-image-format="{string}"]
    [result-image-quality="{number}"]
+   [result-image-aspect="{string}"]
+   [crop-data="{object}"]
+   [original-data="{object}"]
    [on-change="{expression}"]
    [on-load-begin="{expression"]
    [on-load-done="{expression"]
@@ -141,11 +144,11 @@ Assignable angular expression to data-bind to. NgImgCrop puts a data uri of a cr
 
 ### area-min-size
 
-*Optional*. Min. width/height of the crop area (in pixels). Default: 80.
+*Optional*. Min. width of the crop area (in pixels). Default: 80.
 
 ### result-image-size
 
-*Optional*. Width/height of the result image (in pixels). Default: 200.
+*Optional*. Width of the result image (in pixels). Please note, all height values are calculated from the width and aspect ratio values. Default: 200.
 
 ### result-image-format
 
@@ -154,6 +157,18 @@ Assignable angular expression to data-bind to. NgImgCrop puts a data uri of a cr
 ### result-image-quality
 
 *Optional*. Quality of result image. Possible values between 0.0 and 1.0 inclusive. Default: browser default.
+
+### result-image-aspect
+
+*Optional*. Aspect ratio of result image. Possible values are string combinations of width+'x'+height. Default: 1x1.
+
+### crop-data
+
+*Optional*. Object variable to store data about the current crop. Returns object of { width, height, x, y }. Be sure to assign variables using the "dot rule" to avoid issues with prototypal inheritance (ex: image.cropData, instead of cropData).
+
+### original-data
+
+*Optional*. Object variable to store data about the image being cropped. Returns object of { width, height }. Be sure to assign variables using the "dot rule" to avoid issues with prototypal inheritance (ex: image.origData, instead of origData).
 
 ### on-change
 

--- a/source/js/classes/crop-area-circle.js
+++ b/source/js/classes/crop-area-circle.js
@@ -28,10 +28,12 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
   CropAreaCircle.prototype = new CropArea();
 
   CropAreaCircle.prototype._calcCirclePerimeterCoords=function(angleDegrees) {
-    var hSize=this._size/2;
+    var hSize=this._width/2;
+    // circle code didn't account for vSize (both were always same before)
+    var vSize= Math.floor(this._aspect[1] * (this._width/2) / this._aspect[0]);
     var angleRadians=angleDegrees * (Math.PI / 180),
         circlePerimeterX=this._x + hSize * Math.cos(angleRadians),
-        circlePerimeterY=this._y + hSize * Math.sin(angleRadians);
+        circlePerimeterY=this._y + vSize * Math.sin(angleRadians);
     return [circlePerimeterX, circlePerimeterY];
   };
 
@@ -40,7 +42,7 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
   };
 
   CropAreaCircle.prototype._isCoordWithinArea=function(coord) {
-    return Math.sqrt((coord[0]-this._x)*(coord[0]-this._x) + (coord[1]-this._y)*(coord[1]-this._y)) < this._size/2;
+    return Math.sqrt((coord[0]-this._x)*(coord[0]-this._x) + (coord[1]-this._y)*(coord[1]-this._y)) < this._width/2;
   };
   CropAreaCircle.prototype._isCoordWithinBoxResize=function(coord) {
     var resizeIconCenterCoords=this._calcResizeIconCenterCoords();
@@ -49,8 +51,29 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
            coord[1] > resizeIconCenterCoords[1] - hSize && coord[1] < resizeIconCenterCoords[1] + hSize);
   };
 
-  CropAreaCircle.prototype._drawArea=function(ctx,centerCoords,size){
-    ctx.arc(centerCoords[0],centerCoords[1],size/2,0,2*Math.PI);
+  CropAreaCircle.prototype._drawArea= function(ctx,centerCoords,w,h){
+    // old method, drawing circle...
+    // ctx.arc(centerCoords[0],centerCoords[1],size/2,0,2*Math.PI);
+
+    // new method, drawing ellipse using bezier curves
+    var x = centerCoords[0] - w/2.0,
+        y = centerCoords[1] - h/2.0;
+    var kappa = .5522848,
+        ox = (w / 2) * kappa, // control point offset horizontal
+        oy = (h / 2) * kappa, // control point offset vertical
+        xe = x + w,           // x-end
+        ye = y + h,           // y-end
+        xm = x + w / 2,       // x-middle
+        ym = y + h / 2;       // y-middle
+
+    ctx.beginPath();
+    ctx.moveTo(x, ym);
+    ctx.bezierCurveTo(x, ym - oy, xm - ox, y, xm, y);
+    ctx.bezierCurveTo(xm + ox, y, xe, ym - oy, xe, ym);
+    ctx.bezierCurveTo(xe, ym + oy, xm + ox, ye, xm, ye);
+    ctx.bezierCurveTo(xm - ox, ye, x, ym + oy, x, ym);
+    //ctx.closePath(); // not used correctly, see comments (use to close off open path)
+    ctx.stroke();
   };
 
   CropAreaCircle.prototype.draw=function() {
@@ -66,6 +89,8 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
   CropAreaCircle.prototype.processMouseMove=function(mouseCurX, mouseCurY) {
     var cursor='default';
     var res=false;
+    var canvas_h=this._ctx.canvas.height,
+        canvas_w=this._ctx.canvas.width;
 
     this._boxResizeIsHover = false;
     this._areaIsHover = false;
@@ -78,29 +103,40 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
       res=true;
       this._events.trigger('area-move');
     } else if (this._boxResizeIsDragging) {
-        cursor = 'nesw-resize';
-        var iFR, iFX, iFY;
-        iFX = mouseCurX - this._posResizeStartX;
-        iFY = this._posResizeStartY - mouseCurY;
-        if(iFX>iFY) {
-          iFR = this._posResizeStartSize + iFY*2;
-        } else {
-          iFR = this._posResizeStartSize + iFX*2;
-        }
+      cursor = 'nesw-resize';
+      // horizontal distance moved (xMulti adjusts for direction)
+      var iFX = mouseCurX - this._posResizeStartX;
+      // starting crop width + distance moved = new crop width
+      var iFW = this._posResizeStartSize + iFX;
 
-        this._size = Math.max(this._minSize, iFR);
+      var wasWidth=this._width;
+      var wasHeight=this._height;
+      var scale = this.getScale();
+      // rounds up the minimum crop to keep from collapsing crop area below minimum
+      var minSizeScale = Math.ceil(scale*this._minSize);
+      
+      var newWidth= Math.max(minSizeScale, this._unscaledMinSize, iFW);
+      var newHeight= Math.floor(this._aspect[1] * newWidth / this._aspect[0]);
+      if(newWidth <= canvas_w && newHeight <= canvas_h){
+        this._width = newWidth;
+        this._height = newHeight;
+        var x_posModifier=(this._width-wasWidth)/2;
+        var y_posModifier=(this._height-wasHeight)/2;
+        this._x+=x_posModifier;
+        this._y+=y_posModifier*-1;
         this._boxResizeIsHover = true;
         res=true;
         this._events.trigger('area-resize');
+      }
     } else if (this._isCoordWithinBoxResize([mouseCurX,mouseCurY])) {
-        cursor = 'nesw-resize';
-        this._areaIsHover = false;
-        this._boxResizeIsHover = true;
-        res=true;
+      cursor = 'nesw-resize';
+      this._areaIsHover = false;
+      this._boxResizeIsHover = true;
+      res=true;
     } else if(this._isCoordWithinArea([mouseCurX,mouseCurY])) {
-        cursor = 'move';
-        this._areaIsHover = true;
-        res=true;
+      cursor = 'move';
+      this._areaIsHover = true;
+      res=true;
     }
 
     this._dontDragOutside();
@@ -117,7 +153,7 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
       this._boxResizeIsHover = true;
       this._posResizeStartX=mouseDownX;
       this._posResizeStartY=mouseDownY;
-      this._posResizeStartSize = this._size;
+      this._posResizeStartSize = this._width;
       this._events.trigger('area-resize-start');
     } else if (this._isCoordWithinArea([mouseDownX,mouseDownY])) {
       this._areaIsDragging = true;
@@ -145,7 +181,6 @@ crop.factory('cropAreaCircle', ['cropArea', function(CropArea) {
     this._posDragStartX = 0;
     this._posDragStartY = 0;
   };
-
 
   return CropAreaCircle;
 }]);

--- a/source/js/classes/crop-area.js
+++ b/source/js/classes/crop-area.js
@@ -5,14 +5,18 @@ crop.factory('cropArea', ['cropCanvas', function(CropCanvas) {
     this._ctx=ctx;
     this._events=events;
 
-    this._minSize=80;
+    this._minSize = 40;
+    // since minSize is scaled, we need set another minimum regardless of scale
+    this._unscaledMinSize = 40;
 
     this._cropCanvas=new CropCanvas(ctx);
 
     this._image=new Image();
     this._x = 0;
     this._y = 0;
-    this._size = 200;
+    this._width = 200;
+    this._aspect = [1,1];
+    this._height = Math.floor(this._aspect[1] * this._width / this._aspect[0]);
   };
 
   /* GETTERS/SETTERS */
@@ -41,11 +45,34 @@ crop.factory('cropArea', ['cropCanvas', function(CropCanvas) {
   };
 
   CropArea.prototype.getSize = function () {
-    return this._size;
+    return this._width;
   };
   CropArea.prototype.setSize = function (size) {
-    this._size = Math.max(this._minSize, size);
+    // scale is the ratio of image to canvas size
+    var scale = this.getScale();
+    var minSizeScale = Math.round(scale*this._minSize);
+    
+    this._width = Math.max(minSizeScale, this._unscaledMinSize, size);
+    this._height = Math.floor(this._aspect[1] * this._width / this._aspect[0]);    
     this._dontDragOutside();
+  };
+  CropArea.prototype.getWidth = function () {
+    return this._width;
+  };
+  CropArea.prototype.setWidth = function (width) {
+    this.setSize(width);
+  };
+  CropArea.prototype.getHeight = function () {
+    return this._height;
+  };
+  CropArea.prototype.setHeight = function (height) {
+    // determine minHeight based on minWidth and aspect ratio
+    var minHeight = Math.floor(this._aspect[1] * this._minSize / this._aspect[0]);
+    // height is no smaller than minHeight
+    var newHeight = Math.max(minHeight, height);
+    // get conversion of width based on newheight and aspect ratio
+    var newWidth = Math.floor(this._aspect[0] * newHeight / this._aspect[1]);
+    this.setSize(newWidth);
   };
 
   CropArea.prototype.getMinSize = function () {
@@ -53,27 +80,50 @@ crop.factory('cropArea', ['cropCanvas', function(CropCanvas) {
   };
   CropArea.prototype.setMinSize = function (size) {
     this._minSize = size;
-    this._size = Math.max(this._minSize, this._size);
+    this._width = Math.max(this._minSize, this._width);
+    this._height = Math.floor(this._aspect[1] * this._width / this._aspect[0]);
     this._dontDragOutside();
+  };
+
+  CropArea.prototype.getAspect = function () {
+    return this._aspect;
+  };
+  CropArea.prototype.setAspect = function (w, h) {
+    this._aspect = [w,h];
+    this._dontDragOutside();
+  };
+  CropArea.prototype.getScale = function () {
+    var xScale = this._ctx.canvas.width/this._image.width;
+    var yScale = this._ctx.canvas.height/this._image.height;
+
+    // only return real float values
+    if(isNaN(xScale) || isNaN(yScale) || !isFinite(xScale) || !isFinite(yScale)){
+      xScale = 1;
+      yScale = 1;
+    }
+
+    return Math.max(xScale, yScale);
   };
 
   /* FUNCTIONS */
   CropArea.prototype._dontDragOutside=function() {
     var h=this._ctx.canvas.height,
         w=this._ctx.canvas.width;
-    if(this._size>w) { this._size=w; }
-    if(this._size>h) { this._size=h; }
-    if(this._x<this._size/2) { this._x=this._size/2; }
-    if(this._x>w-this._size/2) { this._x=w-this._size/2; }
-    if(this._y<this._size/2) { this._y=this._size/2; }
-    if(this._y>h-this._size/2) { this._y=h-this._size/2; }
+    if(this._width>w) { 
+      this._width=w; 
+    }
+    if(this._height>h) { this._height=h; }
+    if(this._x<this._width/2) { this._x=this._width/2; }
+    if(this._x>w-this._width/2) { this._x=w-this._width/2; }
+    if(this._y<this._height/2) { this._y=this._height/2; }
+    if(this._y>h-this._height/2) { this._y=h-this._height/2; }
   };
 
   CropArea.prototype._drawArea=function() {};
 
   CropArea.prototype.draw=function() {
     // draw crop area
-    this._cropCanvas.drawCropArea(this._image,[this._x,this._y],this._size,this._drawArea);
+    this._cropCanvas.drawCropArea(this._image,[this._x,this._y],this._width,this._height,this._drawArea);
   };
 
   CropArea.prototype.processMouseMove=function() {};

--- a/source/js/classes/crop-area.js
+++ b/source/js/classes/crop-area.js
@@ -5,8 +5,8 @@ crop.factory('cropArea', ['cropCanvas', function(CropCanvas) {
     this._ctx=ctx;
     this._events=events;
 
-    this._minSize = 40;
-    // since minSize is scaled, we need set another minimum regardless of scale
+    this._minSize = 80;
+    // since minSize is scaled, we need to set another minimum regardless of scale
     this._unscaledMinSize = 40;
 
     this._cropCanvas=new CropCanvas(ctx);

--- a/source/js/classes/crop-canvas.js
+++ b/source/js/classes/crop-canvas.js
@@ -52,7 +52,6 @@ crop.factory('cropCanvas', [function() {
         ctx.restore();
     };
 
-
     /* Icons */
 
     this.drawIconMove=function(centerCoords, scale) {
@@ -99,27 +98,32 @@ crop.factory('cropCanvas', [function() {
 
     /* Crop Area */
 
-    this.drawCropArea=function(image, centerCoords, size, fnDrawClipPath) {
+    this.drawCropArea=function(image, centerCoords, width, height, fnDrawClipPath) {
       var xRatio=image.width/ctx.canvas.width,
           yRatio=image.height/ctx.canvas.height,
-          xLeft=centerCoords[0]-size/2,
-          yTop=centerCoords[1]-size/2;
+          xLeft=centerCoords[0]-width/2,
+          yTop=centerCoords[1]-height/2;
 
+      // console.log(image.width+' x '+image.height+' vs '+ctx.canvas.width+' x '+ctx.canvas.height);
       ctx.save();
       ctx.strokeStyle = colors.areaOutline;
       ctx.lineWidth = 2;
       ctx.beginPath();
-      fnDrawClipPath(ctx, centerCoords, size);
+      fnDrawClipPath(ctx, centerCoords, width, height);
       ctx.stroke();
       ctx.clip();
 
+      // prevent factoring beyond the original image dimensions
+      while(width*xRatio > image.width){ width--; }
+      while(height*yRatio > image.height){ height--; }
+
       // draw part of original image
-      if (size > 0) {
-          ctx.drawImage(image, xLeft*xRatio, yTop*yRatio, size*xRatio, size*yRatio, xLeft, yTop, size, size);
+      if (width > 0 && height > 0) {
+          ctx.drawImage(image, xLeft*xRatio, yTop*yRatio, width*xRatio, height*yRatio, xLeft, yTop, width, height);
       }
 
       ctx.beginPath();
-      fnDrawClipPath(ctx, centerCoords, size);
+      fnDrawClipPath(ctx, centerCoords, width, height);
       ctx.stroke();
       ctx.clip();
 

--- a/test/ng-img-crop.html
+++ b/test/ng-img-crop.html
@@ -2,8 +2,8 @@
 <html ng-app="app">
 <head>
   <title>ngImgCrop Test Page</title>
-  <script type="text/javascript" src="../bower_components/angular/angular.min.js"></script>
-  <!--<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>-->
+  <!--<script type="text/javascript" src="../bower_components/angular/angular.min.js"></script>-->
+  <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
   <script type="text/javascript" src="../compile/unminified/ng-img-crop.js"></script>
   <link rel="stylesheet" href="../compile/unminified/ng-img-crop.css"/>
   <style>
@@ -27,63 +27,88 @@
   </style>
 </head>
 <body ng-controller="Ctrl">
-  <div>
-    <label><input type="checkbox" ng-model="enableCrop" ng-init="enableCrop=true"/> Add ngImgCrop to Page</label>
+  <div style="float: left">
+    <div>
+      <label><input type="checkbox" ng-model="enableCrop" ng-init="enableCrop=true"/> Add ngImgCrop to Page</label>
+    </div>
+    <div>
+      Container size:
+      <label><input type="radio" ng-model="size" value="big" /> Big</label>
+      <label><input type="radio" ng-model="size" value="medium" /> Medium</label>
+      <label><input type="radio" ng-model="size" value="small" /> Small</label>
+    </div>
+    <div>
+      Area type:
+      <label><input type="radio" ng-model="type" value="circle" /> Circle</label>
+      <label><input type="radio" ng-model="type" value="square" /> Square</label>
+      <!--<label><input type="radio" ng-model="type" value="rectangle" /> Rectangle</label>-->
+    </div>
+    <div>
+      <label><input type="checkbox" ng-model="changeOnFly" /> Change On Fly</label>
+    </div>
+    
+    <div>
+      Aspect Ratio: 
+      <label><input type="radio" ng-model="aspectRatio" value="1x1" /> 1 x 1</label>
+      <label><input type="radio" ng-model="aspectRatio" value="3x4" /> 3 x 4</label>
+      <label><input type="radio" ng-model="aspectRatio" value="6x2" /> 6 x 2</label>
+    </div>
+    
+    <div>
+      <label>Area Min Size (Size = Width = Height): <input type="text" ng-model="selMinSize" /></label>
+    </div>
+    <div>
+      <label>Result Image Size (Size = Width = Height): <input type="text" ng-model="resImgSize" /></label>
+    </div>
+    <div>
+      Result Image Format:
+      <label><input type="radio" ng-model="resImgFormat" value="image/jpeg" /> image/jpeg</label>
+      <label><input type="radio" ng-model="resImgFormat" value="image/png" /> image/png</label>
+      <label><input type="radio" ng-model="resImgFormat" value="image/webp" /> image/webp</label>
+    </div>
+    <div>
+      <label>Result Image Quality (0<=X<=1): <input type="text" ng-model="resImgQuality" /></label>
+    </div>
+    <form ng-show="enableCrop">
+      <label for="fileInput">Select Image:</label>
+      <input type="file" id="fileInput" />
+      <button type="reset">Clear</button>
+      <button ng-click="imageDataURI='test.jpg'">Set Test Image</button>
+    </form>
+    <div>
+      <label>Image URL: <input type="text" ng-model="edtImageURI" /></label>
+      <button ng-click="imageDataURI=edtImageURI">Set Image</button>
+    </div>
+    <div>
+      <button ng-click="imageDataURI=''">Reset Image</button>
+    </div>
   </div>
-  <div>
-    Container size:
-    <label><input type="radio" ng-model="size" value="big" /> Big</label>
-    <label><input type="radio" ng-model="size" value="medium" /> Medium</label>
-    <label><input type="radio" ng-model="size" value="small" /> Small</label>
+
+  <div style="float:right">
+    <h3>Crop Data:</h3>
+    <ul>
+      <li><b>Width</b>: {{image.cropInfo.width}}</li>
+      <li><b>Height</b>: {{image.cropInfo.height}}</li>
+      <li><b>X</b>: {{image.cropInfo.x}}</li>
+      <li><b>Y</b>: {{image.cropInfo.y}}</li>
+    </ul>
+    <h3>Original Image Data:</h3>
+    <ul>
+      <li><b>Width</b>: {{image.originalInfo.width}}</li>
+      <li><b>Height</b>: {{image.originalInfo.height}}</li>
+    </ul>
   </div>
-  <div>
-    Area type:
-    <label><input type="radio" ng-model="type" value="circle" /> Circle</label>
-    <label><input type="radio" ng-model="type" value="square" /> Square</label>
-    <!--<label><input type="radio" ng-model="type" value="rectangle" /> Rectangle</label>-->
-  </div>
-  <div>
-    <label><input type="checkbox" ng-model="changeOnFly" /> Change On Fly</label>
-  </div>
-  <!--
-  <div>
-    <label>Aspect Ratio: <input type="text" ng-model="aspectRatio" /></label>
-  </div>
-  -->
-  <div>
-    <label>Area Min Size (Size = Width = Height): <input type="text" ng-model="selMinSize" /></label>
-  </div>
-  <div>
-    <label>Result Image Size (Size = Width = Height): <input type="text" ng-model="resImgSize" /></label>
-  </div>
-  <div>
-    Result Image Format:
-    <label><input type="radio" ng-model="resImgFormat" value="image/jpeg" /> image/jpeg</label>
-    <label><input type="radio" ng-model="resImgFormat" value="image/png" /> image/png</label>
-    <label><input type="radio" ng-model="resImgFormat" value="image/webp" /> image/webp</label>
-  </div>
-  <div>
-    <label>Result Image Quality (0<=X<=1): <input type="text" ng-model="resImgQuality" /></label>
-  </div>
-  <form ng-show="enableCrop">
-    <label for="fileInput">Select Image:</label>
-    <input type="file" id="fileInput" />
-    <button type="reset">Clear</button>
-    <button ng-click="imageDataURI='test.jpg'">Set Test Image</button>
-  </form>
-  <div>
-    <label>Image URL: <input type="text" ng-model="edtImageURI" /></label>
-    <button ng-click="imageDataURI=edtImageURI">Set Image</button>
-  </div>
-  <div>
-    <button ng-click="imageDataURI=''">Reset Image</button>
-  </div>
+
+  <div style="clear:both"></div>
 
   <div ng-if="enableCrop" class="cropArea" ng-class="{'big':size=='big', 'medium':size=='medium', 'small':size=='small'}">
     <img-crop image="imageDataURI"
               result-image="$parent.resImageDataURI"
               change-on-fly="changeOnFly"
               area-type="{{type}}"
+              result-image-aspect="{{aspectRatio}}"
+              crop-data="image.cropInfo"
+              original-data="image.originalInfo"
               area-min-size="selMinSize"
               result-image-format="{{resImgFormat}}"
               result-image-quality="resImgQuality"
@@ -95,9 +120,8 @@
     ></img-crop>
               <!--aspect-ratio="aspectRatio"-->
   </div>
-
   <div style="text-align:center">
-    <h3>Result</h3>
+    <h3>Result:</h3>
     <div>
       <img ng-src="{{resImageDataURI}}" />
     </div>
@@ -108,6 +132,11 @@
       .controller('Ctrl', function($scope) {
         $scope.size='small';
         $scope.type='circle';
+        $scope.aspectRatio='1x1';
+        $scope.image = {
+          originalInfo: {},
+          cropInfo: {}
+        };
         $scope.imageDataURI='';
         $scope.resImageDataURI='';
         $scope.resImgFormat='image/png';

--- a/test/ng-img-crop.html
+++ b/test/ng-img-crop.html
@@ -2,8 +2,8 @@
 <html ng-app="app">
 <head>
   <title>ngImgCrop Test Page</title>
-  <!--<script type="text/javascript" src="../bower_components/angular/angular.min.js"></script>-->
-  <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
+  <script type="text/javascript" src="../bower_components/angular/angular.min.js"></script>
+  <!-- <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script> -->
   <script type="text/javascript" src="../compile/unminified/ng-img-crop.js"></script>
   <link rel="stylesheet" href="../compile/unminified/ng-img-crop.css"/>
   <style>


### PR DESCRIPTION
Quick note: I don't have Gulp installed, so I didn't create the compiled files that way. I manually pieced together the compiled, unminified version of the JS file though.

Here is a list of updates:
- aspect ratio
  - passed in as a string (width + 'x' + height)
  - defaults to 1x1 (square)
  - adjusted the square and circle classes to work as rectangle and ellipses classes
- passes crop data and original image data, as attributes
  - crop data = { width, height, x, y }
  - original data = { width, height }
  - crop data is 2-way binding, so that users can initiate the canvas to a specific crop
    - if initiated out of bounds, it adjusts values to fit
  - X and Y coordinates are based on left-top corner
- fixes issue with canvas redrawing incorrectly after being hidden
  - when the canvas is hidden it's clientHeight is set to 0, which basically tells the code to redraw everything to minimum values
  - added an if statement to prevent redrawing when the clientHeight is 0
- initializes the crop to the maximum possible from the middle of the image
  - this is useful in projects where using the cropping tool is optional to the user, and creating a cropped image (to fit a particular aspect ratio) is required on the back-end
- updated the test HTML file to show the recent changes
- updated the README.md to reflect some of the recent changes

