### PR TITLE
Made sure width and height of cropped image do not exceed image size

### DIFF
--- a/source/js/classes/crop-canvas.js
+++ b/source/js/classes/crop-canvas.js
@@ -103,7 +103,16 @@ crop.factory('cropCanvas', [function() {
       var xRatio=image.width/ctx.canvas.width,
           yRatio=image.height/ctx.canvas.height,
           xLeft=centerCoords[0]-size/2,
-          yTop=centerCoords[1]-size/2;
+          yTop=centerCoords[1]-size/2,
+          clipWidth=size*xRatio,
+          clipHeight=size*yRatio;
+       
+      if (clipWidth > image.width){
+        clipWidth = image.width;
+      }
+      if (clipHeight > image.height){
+        clipHeight = image.height;
+      }
 
       ctx.save();
       ctx.strokeStyle = colors.areaOutline;
@@ -115,7 +124,7 @@ crop.factory('cropCanvas', [function() {
 
       // draw part of original image
       if (size > 0) {
-          ctx.drawImage(image, xLeft*xRatio, yTop*yRatio, size*xRatio, size*yRatio, xLeft, yTop, size, size);
+          ctx.drawImage(image, xLeft*xRatio, yTop*yRatio, clipWidth, clipHeight, xLeft, yTop, size, size);
       }
 
       ctx.beginPath();

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -165,13 +165,22 @@ crop.factory('cropHost', ['$document', 'cropAreaCircle', 'cropAreaSquare', 'crop
 
 
     this.getResultImageDataURI=function() {
-      var temp_ctx, temp_canvas;
+      var temp_ctx, temp_canvas,
+          clipWidth, clipHeight;
       temp_canvas = angular.element('<canvas></canvas>')[0];
       temp_ctx = temp_canvas.getContext('2d');
       temp_canvas.width = resImgSize;
       temp_canvas.height = resImgSize;
-      if(image!==null){
-        temp_ctx.drawImage(image, (theArea.getX()-theArea.getSize()/2)*(image.width/ctx.canvas.width), (theArea.getY()-theArea.getSize()/2)*(image.height/ctx.canvas.height), theArea.getSize()*(image.width/ctx.canvas.width), theArea.getSize()*(image.height/ctx.canvas.height), 0, 0, resImgSize, resImgSize);
+      if(image!==null) {
+        clipWidth = theArea.getSize()*(image.width/ctx.canvas.width);
+        clipHeight = theArea.getSize()*(image.height/ctx.canvas.height);
+        if (clipWidth > image.width){
+          clipWidth = image.width;
+        }
+        if (clipHeight > image.height){
+          clipHeight = image.height;
+        }
+        temp_ctx.drawImage(image, (theArea.getX()-theArea.getSize()/2)*(image.width/ctx.canvas.width), (theArea.getY()-theArea.getSize()/2)*(image.height/ctx.canvas.height), clipWidth, clipHeight, 0, 0, resImgSize, resImgSize);
       }
       if (resImgQuality!==null ){
         return temp_canvas.toDataURL(resImgFormat, resImgQuality);


### PR DESCRIPTION
Fixes #43.

On firefox, due to floating point precision issues, in some cases `size*xRatio` ends up becoming something like 0.0000006 bigger than image width. This just makes sure the clip height and width do not go beyond image boundaries