### PR TITLE
Fix for issue whereby images with EXIF rotation don't get displayed

### DIFF
--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -225,11 +225,15 @@ crop.factory('cropHost', ['$document', 'cropAreaCircle', 'cropAreaSquare', 'crop
 
               image=new Image();
               image.src = canvas.toDataURL("image/png");
+              image.onload = function(){
+                resetCropHost();
+                events.trigger('image-updated');
+              };
             } else {
               image=newImage;
+              resetCropHost();
+              events.trigger('image-updated');
             }
-            resetCropHost();
-            events.trigger('image-updated');
           });
         };
         newImage.onerror=function() {


### PR DESCRIPTION
Images from digital cameras with embedded EXIF data which indicates they need rotation sometimes won't display as resetCropHost is called too early
