### PR TITLE
Adding path to 'main' in package.json for module loaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "version": "0.3.2",
   "description": "Image crop directive for AngularJS",
   "license": "MIT",
+  "main": "compile/minified/ng-img-crop.js",
   "homepage": "https://github.com/alexk111/ngImgCrop",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows developers to use the package with a module loader instead of a file path reference. For example in Webpack, you could import it by `require('ng-img-crop)`